### PR TITLE
Add exp validation and respond with a 401 when a token is expired

### DIFF
--- a/authentic_go_suite_test.go
+++ b/authentic_go_suite_test.go
@@ -1,4 +1,4 @@
-package authentic_test
+package authentic
 
 import (
 	"testing"

--- a/clock.go
+++ b/clock.go
@@ -1,0 +1,17 @@
+package authentic
+
+import (
+	"time"
+)
+
+type (
+	Clock interface {
+		IsBeforeNow(time.Time) bool
+	}
+
+	clock struct{}
+)
+
+func (c *clock) IsBeforeNow(t time.Time) bool {
+	return time.Now().UTC().Before(t)
+}

--- a/gin.go
+++ b/gin.go
@@ -21,11 +21,7 @@ func (m *middlewareCreator) CreateGinMiddleware() gin.HandlerFunc {
 				return
 			}
 
-			if result.Expired {
-				c.AbortWithStatusJSON(http.StatusForbidden, m.notAuthorizedError())
-				return
-			}
-
+			// Per RFC responding with a 401 whether invalid or expired
 			c.AbortWithStatusJSON(http.StatusUnauthorized, m.notAuthorizedError())
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -19,14 +19,18 @@ type (
 		CreateGinMiddleware() gin.HandlerFunc
 		OnSuccess(gin.HandlerFunc) MiddlewareCreator
 		OnFailure(gin.HandlerFunc) MiddlewareCreator
+		WithValidator(Validator) MiddlewareCreator
 	}
 
 	// Validator interface for validating a JWT
 	Validator interface {
 		// IsValid check the validity of a JWT token
+		ValidateToken(string) *Result
 		IsValid(string) bool
+		IsExpired(map[string]interface{}) bool
 		WithWhitelist(...string) Validator
 		WithCacheMaxAge(time.Duration) Validator
+		withClock(Clock) Validator
 	}
 )
 
@@ -37,6 +41,7 @@ func NewValidator() Validator {
 		CacheMaxAge:  time.Hour * time.Duration(cacheMaxAgeHours),
 		ISSWhitelist: strings.Split(os.Getenv("ISS_WHITELIST"), "|"),
 		keyManager:   newKeyManager(),
+		clock:        &clock{},
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -217,7 +217,7 @@ var _ = Describe("authentic", func() {
 				Expect(body.Message).To(Equal("Unauthorized"))
 			})
 
-			It("returns 403 response in Gin middleware due to expired token", func() {
+			It("returns 401 response in Gin middleware due to expired token", func() {
 				expiredMiddlewareCreator.CreateGinMiddleware()(mockContext)
 				json.NewDecoder(rec.Body).Decode(&body)
 				Expect(rec.Code).To(Equal(401))

--- a/main_test.go
+++ b/main_test.go
@@ -220,7 +220,7 @@ var _ = Describe("authentic", func() {
 			It("returns 403 response in Gin middleware due to expired token", func() {
 				expiredMiddlewareCreator.CreateGinMiddleware()(mockContext)
 				json.NewDecoder(rec.Body).Decode(&body)
-				Expect(rec.Code).To(Equal(403))
+				Expect(rec.Code).To(Equal(401))
 			})
 
 			It("does not respond with a valid token", func() {

--- a/main_test.go
+++ b/main_test.go
@@ -1,4 +1,4 @@
-package authentic_test
+package authentic
 
 import (
 	"encoding/json"
@@ -10,18 +10,13 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-
-	"gopkg.in/h2non/gock.v1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
-	"github.com/articulate/authentic-go"
+	"gopkg.in/h2non/gock.v1"
 )
 
 const (
-	wellKnown = "/.well-known/openid-configuration"
-	testUrl   = "https://authentic.articulate.com"
+	testUrl = "https://authentic.articulate.com"
 
 	badIss = "eyJraWQiOiJEYVgxMWdBcldRZWJOSE83RU1QTUw1VnRUNEV3cmZrd2M1U2xHaVd2VXdBIiwiYWxnIjoiUlMyNTYifQ.eyJzdWIiOiIwMH0V" +
 		"kanlqc3NidDJTMVFWcjBoNyIsInZlciI6MSwiaXNzIjoiaHR0cHM6Ly9iYWQtaXNzLmNvbSIsImF1ZCI6IjBvYWRqeWs1MjNobFpmeWIxMGg3IiwiaWF0" +
@@ -52,10 +47,21 @@ const (
 )
 
 var (
-	oidc      interface{}
-	keys      interface{}
-	validator authentic.Validator
+	oidc            interface{}
+	keys            interface{}
+	expiredStamp    int64 = 1516640000
+	notExpiredStamp int64 = 1516640800
 )
+
+type (
+	testClock struct {
+		now time.Time
+	}
+)
+
+func (c *testClock) IsBeforeNow(t time.Time) bool {
+	return c.now.Before(t)
+}
 
 func jsonFixture(file string) interface{} {
 	var body interface{}
@@ -67,7 +73,16 @@ func jsonFixture(file string) interface{} {
 }
 
 var _ = Describe("authentic", func() {
+	var (
+		validator                Validator
+		expiredValidator         Validator
+		middlewareCreator        MiddlewareCreator
+		expiredMiddlewareCreator MiddlewareCreator
+	)
+
 	Describe("Validator", func() {
+		validTestClock := &testClock{now: time.Unix(notExpiredStamp, 0)}
+		expiredTestClock := &testClock{now: time.Unix(expiredStamp, 0)}
 		BeforeEach(func() {
 			oidc = jsonFixture("oidc.json")
 			keys = jsonFixture("keys.json")
@@ -81,8 +96,14 @@ var _ = Describe("authentic", func() {
 				Get("/v1/keys").
 				Reply(200).
 				JSON(keys)
-			validator = authentic.NewValidator().
-				WithWhitelist("https://org.auth0.com/", "https://org.okta.com/")
+			validator = NewValidator().
+				WithWhitelist("https://org.auth0.com/", "https://org.okta.com/").
+				withClock(validTestClock)
+			expiredValidator = NewValidator().
+				WithWhitelist("https://org.auth0.com/", "https://org.okta.com/").
+				withClock(expiredTestClock)
+			middlewareCreator = NewMiddlewareCreator().WithValidator(validator)
+			expiredMiddlewareCreator = NewMiddlewareCreator().WithValidator(expiredValidator)
 		})
 
 		It("validates JWT against JWK", func() {
@@ -95,6 +116,18 @@ var _ = Describe("authentic", func() {
 
 		It("fails to validate valid token with wrong iss", func() {
 			Expect(validator.IsValid(badIss)).To(BeFalse())
+		})
+
+		It("sets result to Valid false", func() {
+			Expect(validator.ValidateToken(badIss).Valid).To(BeFalse())
+		})
+
+		It("correctly determines the token is expired", func() {
+			Expect(expiredValidator.ValidateToken(token).Expired).To(BeTrue())
+		})
+
+		It("correctly determines the token is not expired", func() {
+			Expect(validator.ValidateToken(token).Expired).To(BeFalse())
 		})
 
 		It("caches key and only makes one request", func() {
@@ -113,14 +146,14 @@ var _ = Describe("authentic", func() {
 				Get("/v1/keys").
 				Reply(200).
 				JSON(keys)
-			validator = authentic.NewValidator().WithCacheMaxAge(time.Microsecond)
+			validator = NewValidator().WithCacheMaxAge(time.Microsecond)
 			Expect(validator.IsValid(token)).To(BeTrue())
 			time.Sleep(time.Microsecond)
 			Expect(validator.IsValid(token)).To(BeTrue())
 		})
 
 		It("serves stale when request fails, but tries again subsequentially", func() {
-			validator = authentic.NewValidator().WithCacheMaxAge(time.Microsecond)
+			validator = NewValidator().WithCacheMaxAge(time.Microsecond)
 			Expect(validator.IsValid(token)).To(BeTrue())
 			gock.New(testUrl).
 				Times(1).
@@ -160,13 +193,13 @@ var _ = Describe("authentic", func() {
 
 		Context("middleware", func() {
 			var (
-				body        *authentic.ErrorResponse
+				body        *ErrorResponse
 				rec         *httptest.ResponseRecorder
 				mockContext *gin.Context
 			)
 
 			BeforeEach(func() {
-				body = &authentic.ErrorResponse{}
+				body = &ErrorResponse{}
 				rec = httptest.NewRecorder()
 				mockContext, _ = gin.CreateTestContext(rec)
 				mockContext.Request = &http.Request{
@@ -178,14 +211,20 @@ var _ = Describe("authentic", func() {
 
 			It("returns 401 response in Gin middleware", func() {
 				mockContext.Request.Header["Authorization"] = []string{"Bearer " + badToken}
-				authentic.NewMiddlewareCreator().CreateGinMiddleware()(mockContext)
+				middlewareCreator.CreateGinMiddleware()(mockContext)
 				json.NewDecoder(rec.Body).Decode(&body)
 				Expect(rec.Code).To(Equal(401))
 				Expect(body.Message).To(Equal("Unauthorized"))
 			})
 
+			It("returns 403 response in Gin middleware due to expired token", func() {
+				expiredMiddlewareCreator.CreateGinMiddleware()(mockContext)
+				json.NewDecoder(rec.Body).Decode(&body)
+				Expect(rec.Code).To(Equal(403))
+			})
+
 			It("does not respond with a valid token", func() {
-				authentic.NewMiddlewareCreator().CreateGinMiddleware()(mockContext)
+				middlewareCreator.CreateGinMiddleware()(mockContext)
 				Expect(rec.Code).To(Equal(200))
 			})
 		})

--- a/middleware.go
+++ b/middleware.go
@@ -30,9 +30,22 @@ func (m *middlewareCreator) OnSuccess(hook gin.HandlerFunc) MiddlewareCreator {
 	return m
 }
 
+// WithValidator explicitly set a validator to use
+func (m *middlewareCreator) WithValidator(v Validator) MiddlewareCreator {
+	m.Validator = v
+	return m
+}
+
 func (m *middlewareCreator) notAuthorizedError() *ErrorResponse {
 	return &ErrorResponse{
 		Message: "Unauthorized",
+		Causes:  []string{"Invalid session"},
+	}
+}
+
+func (m *middlewareCreator) forbiddenError() *ErrorResponse {
+	return &ErrorResponse{
+		Message: "Forbidden",
 		Causes:  []string{"Invalid session"},
 	}
 }

--- a/validator.go
+++ b/validator.go
@@ -8,27 +8,42 @@ import (
 )
 
 type (
+	Result struct {
+		Claims  map[string]interface{}
+		Valid   bool
+		Expired bool
+	}
+
 	validator struct {
 		CacheMaxAge  time.Duration
 		ISSWhitelist []string
 		keyManager   *keyManager
+		clock        Clock
 	}
 )
 
-// IsValid verifies JWT token
+// IsValid checks validity of token and ensures it is not expired
 func (v *validator) IsValid(token string) bool {
+	result := v.ValidateToken(token)
+	return result.Valid && !result.Expired
+}
+
+// ValidateToken verifies JWT token, and returns result
+func (v *validator) ValidateToken(token string) *Result {
 	var (
 		claims map[string]interface{}
 		header jose.Header
 		key    *jose.JSONWebKey
+		result = &Result{}
 	)
 	parsedToken, err := jwt.ParseSigned(token)
 	if err != nil {
-		return false
+		return result
 	}
+	// Note this is required to get the iss, the call to Claims later on validates the claims
 	err = parsedToken.UnsafeClaimsWithoutVerification(&claims)
 	if err != nil {
-		return false
+		return result
 	}
 
 	for _, h := range parsedToken.Headers {
@@ -42,11 +57,24 @@ func (v *validator) IsValid(token string) bool {
 
 	// If JWT has no corresponding JWK, JWK is invalid, or JWT encryption algorithm does not match the JWKs
 	if key == nil || !key.Valid() || key.Algorithm != header.Algorithm {
-		return false
+		return result
 	}
 
 	if err = parsedToken.Claims(key.Key, &claims); err != nil {
-		return false
+		return result
+	}
+	result.Valid = true
+	result.Claims = claims
+	result.Expired = v.IsExpired(result.Claims)
+
+	return result
+}
+
+func (v *validator) IsExpired(claims map[string]interface{}) bool {
+	if exp, ok := claims["exp"].(float64); ok {
+		tm := time.Unix(int64(exp), 0)
+
+		return v.clock.IsBeforeNow(tm)
 	}
 
 	return true
@@ -61,5 +89,10 @@ func (v *validator) WithWhitelist(whitelist ...string) Validator {
 // WithCacheMaxAge set cache max age
 func (v *validator) WithCacheMaxAge(c time.Duration) Validator {
 	v.CacheMaxAge = c
+	return v
+}
+
+func (v *validator) withClock(c Clock) Validator {
+	v.clock = c
 	return v
 }


### PR DESCRIPTION
Related https://github.com/articulate/authentic-rb/pull/7

We had another task to ensure we were validating the exp claim so this adds that here as well. The JWT library I chose doesn't do any claim value validation, just ensures they are signed.